### PR TITLE
Add a buffer parameter to __init__

### DIFF
--- a/src/pa_ringbuffer.py
+++ b/src/pa_ringbuffer.py
@@ -76,12 +76,18 @@ class _RingBufferBase(object):
     :param size: The number of elements in the buffer (must be a
         power of 2).
     :type size: int
+    :param buffer: optional pre-allocated buffer to use with RingBuffer
+    :type buffer: buffer
 
     """
 
-    def __init__(self, elementsize, size):
+    def __init__(self, elementsize, size, buffer=None):
         self._ptr = self._ffi.new('PaUtilRingBuffer*')
-        self._data = self._ffi.new('unsigned char[]', size * elementsize)
+        if buffer is None:
+            self._data = self._ffi.new('unsigned char[]', size * elementsize)
+        else:
+            self._data = self._ffi.from_buffer(buffer)
+
         res = self._lib.PaUtil_InitializeRingBuffer(
             self._ptr, elementsize, size, self._data)
         if res != 0:

--- a/src/pa_ringbuffer.py
+++ b/src/pa_ringbuffer.py
@@ -71,6 +71,10 @@ class _RingBufferBase(object):
     Python thread to another Python thread.  For this, the `queue.Queue`
     class from the standard library can be used.
 
+    Note that if you pass a read-only buffer object, you still get a writable
+    RingBuffer; it is your responsibility not to write there if the original
+    buffer doesn’t expect you to.
+
     :param elementsize: The size of a single data element in bytes.
     :type elementsize: int
     :param size: The number of elements in the buffer (must be a power
@@ -89,7 +93,7 @@ class _RingBufferBase(object):
                     "size is required when buffer parameter is not specified")
             self._data = self._ffi.new('unsigned char[]', size * elementsize)
         elif size is not None:
-            raise TypeError('exactly one of {size, buffer} is required')            
+            raise TypeError('exactly one of {size, buffer} is required')
         else:
             try:
                 data = self._ffi.from_buffer(buffer)

--- a/src/pa_ringbuffer.py
+++ b/src/pa_ringbuffer.py
@@ -85,9 +85,11 @@ class _RingBufferBase(object):
         self._ptr = self._ffi.new('PaUtilRingBuffer*')
         if buffer is None:
             if size is None:
-                raise ValueError(
+                raise TypeError(
                     "size is required when buffer parameter is not specified")
             self._data = self._ffi.new('unsigned char[]', size * elementsize)
+        elif size is not None:
+            raise TypeError('exactly one of {size, buffer} is required')            
         else:
             try:
                 data = self._ffi.from_buffer(buffer)


### PR DESCRIPTION
Allow usage of a preallocated buffer for the ringbuffer by adding a
``buffer`` parameter to ``__init__``